### PR TITLE
add simple argparse args for connection

### DIFF
--- a/curses-client.py
+++ b/curses-client.py
@@ -7,7 +7,7 @@ V 0.1.7
 '''
 
 import curses
-import meshtastic.serial_interface, meshtastic.tcp_interface
+import meshtastic.serial_interface, meshtastic.tcp_interface, meshtastic.ble_interface
 from pubsub import pub
 import textwrap  # Import the textwrap module
 
@@ -19,9 +19,55 @@ except ImportError:
 
 from settings import settings
 
+import argparse
+
+parser = argparse.ArgumentParser(
+        add_help=False,
+        epilog="If no connection arguments are specified, we attempt a serial connection and then a TCP connection to localhost.")
+
+connOuter = parser.add_argument_group('Connection', 'Optional arguments to specify a device to connect to and how.')
+conn = connOuter.add_mutually_exclusive_group()
+conn.add_argument(
+    "--port",
+    "--serial",
+    "-s",
+    help="The port to connect to via serial, e.g. `/dev/ttyUSB0`.",
+    nargs="?",
+    default=None,
+    const=None,
+)
+conn.add_argument(
+    "--host",
+    "--tcp",
+    "-t",
+    help="The hostname or IP address to connect to using TCP.",
+    nargs="?",
+    default=None,
+    const="localhost",
+)
+conn.add_argument(
+    "--ble",
+    "-b",
+    help="The BLE device MAC address or name to connect to.",
+    nargs="?",
+    default=None,
+    const="any"
+)
+
+args = parser.parse_args()
+
 # Initialize Meshtastic interface
-interface = meshtastic.serial_interface.SerialInterface()
-# interface = meshtastic.tcp_interface.TCPInterface(hostname='192.168.xx.xx')
+if args.ble:
+    interface = meshtastic.ble_interface.BLEInterface(args.ble if args.ble != "any" else None)
+elif args.host:
+    interface = meshtastic.tcp_interface.TCPInterface(args.host)
+else:
+    try:
+        interface = meshtastic.serial_interface.SerialInterface(args.port)
+    except PermissionError as ex:
+        print("You probably need to add yourself to the `dialout` group to use a serial connection.")
+    if interface.devPath is None:
+        interface = meshtastic.tcp_interface.TCPInterface("localhost")
 
 myinfo = interface.getMyNodeInfo()
 
@@ -448,3 +494,4 @@ pub.subscribe(on_receive, 'meshtastic.receive')
 
 if __name__ == "__main__":
     curses.wrapper(main)
+


### PR DESCRIPTION
These should work just like the python CLI ones. Easy way to support the different connection types, at least.