### PR TITLE
Fix crash when wrapping with wide characters

### DIFF
--- a/contact/ui/contact_ui.py
+++ b/contact/ui/contact_ui.py
@@ -1,5 +1,4 @@
 import curses
-import textwrap
 import logging
 import traceback
 from typing import Union
@@ -12,7 +11,7 @@ from contact.utilities.db_handler import get_name_from_database, update_node_inf
 from contact.utilities.input_handlers import get_list_input
 import contact.ui.default_config as config
 import contact.ui.dialog
-from contact.ui.nav_utils import move_main_highlight, draw_main_arrows, get_msg_window_lines
+from contact.ui.nav_utils import move_main_highlight, draw_main_arrows, get_msg_window_lines, wrap_text
 from contact.utilities.singleton import ui_state, interface_state
 
 
@@ -549,7 +548,7 @@ def draw_messages_window(scroll_to_bottom: bool = False) -> None:
         row = 0
         for prefix, message in messages:
             full_message = f"{prefix}{message}"
-            wrapped_lines = textwrap.wrap(full_message, messages_win.getmaxyx()[1] - 2)
+            wrapped_lines = wrap_text(full_message, messages_win.getmaxyx()[1])
             msg_line_count += len(wrapped_lines)
             messages_pad.resize(msg_line_count, messages_win.getmaxyx()[1])
 

--- a/contact/ui/nav_utils.py
+++ b/contact/ui/nav_utils.py
@@ -1,5 +1,7 @@
 import curses
 import re
+from unicodedata import east_asian_width
+
 from contact.ui.colors import get_color
 from contact.utilities.control_utils import transform_menu_path
 from typing import Any, Optional, List, Dict
@@ -293,6 +295,8 @@ def get_wrapped_help_text(
 
     return wrapped_help
 
+def text_width(text: str) -> int:
+    return sum(2 if east_asian_width(c) in "FW" else 1 for c in text)
 
 def wrap_text(text: str, wrap_width: int) -> List[str]:
     """Wraps text while preserving spaces and breaking long words."""
@@ -304,7 +308,7 @@ def wrap_text(text: str, wrap_width: int) -> List[str]:
     wrap_width -= margin
 
     for word in words:
-        word_length = len(word)
+        word_length = text_width(word)
 
         if word_length > wrap_width:  # Break long words
             if line_buffer:


### PR DESCRIPTION
Update contact_ui.py to use already-existing custom wrap function implemented in nav_utils instead of textwrap library. Update custom wrap_text function to use east_asian_width to determine characters that can use two columns of width.

No YOU implemented and debugged an entirely new text wrapping function from scratch before noticing there was already one already named wrap_text in this repo that only needed a small tweak to work for this.

Fixes #186